### PR TITLE
Proposal: use "dépôt" instead of anglicism "repo"

### DIFF
--- a/notebooks/1-01-introduction-video.ipynb
+++ b/notebooks/1-01-introduction-video.ipynb
@@ -357,8 +357,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* on a utilisé dans la vidéo un repo `github.com` **public** parce que c'est pratique\n",
-    "  * on peut facilement créer des repos **privés**\n",
+    "* on a utilisé dans la vidéo un dépôt `github.com` **public** parce que c'est pratique\n",
+    "  * on peut facilement créer des dépôts **privés**\n",
     "* on peut facilement déployer sa propre infra \n",
     "  * si on a des données plus sensibles\n",
     "* l'aspect confidentialité n'est pas un obstacle"
@@ -374,7 +374,7 @@
    "source": [
     "Les trois gros joueurs - github, gitlab et bitbucket - se démènent naturellement pour attirer à eux la plus grosse part de marché. \n",
     "\n",
-    "Avant le début 2019, `github` réservait les repos privés aux utilisateurs payants. Depuis cette date cette limitation est tombée, chacun peut donc créer autant repos privés que nécessaire. \n",
+    "Avant le début 2019, `github` réservait les dépôts privés aux utilisateurs payants. Depuis cette date cette limitation est tombée, chacun peut donc créer autant dépôts privés que nécessaire. \n",
     "\n",
     "L'angle d'attaque de `gitlab` est de proposer une solution facilement déployable sur une infra privée.\n",
     "\n",

--- a/notebooks/1-02-architecture.ipynb
+++ b/notebooks/1-02-architecture.ipynb
@@ -54,7 +54,7 @@
     }
    },
    "source": [
-    "Il n'est pas nécessaire d'utiliser `github` ou une autre infrastructure pour commencer avec `git`. Au contraire il semble préférable de commencer à utiliser *git* localement pour bien se familiariser avec les concepts centraux que sont **le commit**, **l'index**, **la branche**, **le remote**, et bien maitriser les différences pendantes. Il est très facile, à partir d'un repo local, de s'étendre à `github` ou autre.\n",
+    "Il n'est pas nécessaire d'utiliser `github` ou une autre infrastructure pour commencer avec `git`. Au contraire il semble préférable de commencer à utiliser *git* localement pour bien se familiariser avec les concepts centraux que sont **le commit**, **l'index**, **la branche**, **le remote**, et bien maitriser les différences pendantes. Il est très facile, à partir d'un dépôt local, de s'étendre à `github` ou autre.\n",
     "\n",
     "De la même façon il n'est pas nécessaire d'attendre de réaliser un projet en équipe pour bénéficier des avantages que procure un système comme *git*."
    ]
@@ -121,7 +121,7 @@
     }
    },
    "source": [
-    "* via un repo distant (e.g. github)\n",
+    "* via un dépôt distant (e.g. github)\n",
     "* chacun peut modifier tout le code\n",
     "  * `git` se charge de l'intégration des modifications\n",
     "* permettre un travail très fluide en petite équipe\n",
@@ -137,7 +137,7 @@
     }
    },
    "source": [
-    "En exposant un repo sur une infrastructure accessible par tous, on crée un point d'échange qui permet le travail en groupe. \n",
+    "En exposant un dépôt sur une infrastructure accessible par tous, on crée un point d'échange qui permet le travail en groupe. \n",
     "\n",
     "On verra que l'architecture de `git` est extrêment flexible, et permet de faire face à tous les cas de figure."
    ]
@@ -192,7 +192,7 @@
     "\n",
     "* `git` a pris le contrepied total de cette approche\n",
     "  * on peut commencer dans son coin\n",
-    "  * et créer ensuite des liens de *peering* entre deux repos \n",
+    "  * et créer ensuite des liens de *peering* entre deux dépôts \n",
     "  * de façon à implémenter des workflows aussi simples ou complexes que nécessaire"
    ]
   },
@@ -244,7 +244,7 @@
     }
    },
    "source": [
-    "Ici notre auteur a publié son repo sur github; la coulaur gris clair indique que sur github, il s'agit d'un *bare* repo, un repo 'nu', on en reparlera bien sûr."
+    "Ici notre auteur a publié son dépôt sur github; la coulaur gris clair indique que sur github, il s'agit d'un *bare* dépôt, un dépôt 'nu', on en reparlera bien sûr."
    ]
   },
   {
@@ -269,7 +269,7 @@
     }
    },
    "source": [
-    "Maintenant que le premier auteur a publié sur github, un de ses amis peut accéder a ce repo, et du coup se créer un troisième repo sur son ordinateur; les échanges entre les deux personnes se font tous au travers de github."
+    "Maintenant que le premier auteur a publié sur github, un de ses amis peut accéder a ce dépôt, et du coup se créer un troisième dépôt sur son ordinateur; les échanges entre les deux personnes se font tous au travers de github."
    ]
   },
   {
@@ -294,7 +294,7 @@
     }
    },
    "source": [
-    "Dans le cas ou le contributeur est inconnu de l'auteur, le contributeur n'a **pas les droits d'accès en écriture** dans le repo `github`; pour pouvoir malgré tout proposer des améliorations à l'auteur, le contributeur se crée un *fork* où il aura cette fois le droit d'écrire; le fork est simplement un quatrième repo, toujours sur github, dans lequel le contributeur a les droits d'écrire, il peut ainsi exposer ses propositions. On reparlera de ce cas d'usage vers la fin du cours."
+    "Dans le cas ou le contributeur est inconnu de l'auteur, le contributeur n'a **pas les droits d'accès en écriture** dans le dépôt `github`; pour pouvoir malgré tout proposer des améliorations à l'auteur, le contributeur se crée un *fork* où il aura cette fois le droit d'écrire; le fork est simplement un quatrième dépôt, toujours sur github, dans lequel le contributeur a les droits d'écrire, il peut ainsi exposer ses propositions. On reparlera de ce cas d'usage vers la fin du cours."
    ]
   },
   {
@@ -319,7 +319,7 @@
     }
    },
    "source": [
-    "Dans cette configuration, totalement différente, on a illustré le cas de deux équipes, une aux USA et une en France, qui collaborent sur le même sujet mais veulent préserver leur indépendance, ou en tous cas intégrer - ou pas - les idées de l'uutre équipe, mais chacun à son rythme. Pour un tel scénario, on peut imaginer une architecture avec de chaque coté un dépôt d'intégration, et un lien entre ces deux repos pour permettre d'aller - plus ou moins automatiquement selon les besoins - adopter les nouveautés de l'autre équipe."
+    "Dans cette configuration, totalement différente, on a illustré le cas de deux équipes, une aux USA et une en France, qui collaborent sur le même sujet mais veulent préserver leur indépendance, ou en tous cas intégrer - ou pas - les idées de l'uutre équipe, mais chacun à son rythme. Pour un tel scénario, on peut imaginer une architecture avec de chaque coté un dépôt d'intégration, et un lien entre ces deux dépôts pour permettre d'aller - plus ou moins automatiquement selon les besoins - adopter les nouveautés de l'autre équipe."
    ]
   },
   {
@@ -330,14 +330,14 @@
     }
    },
    "source": [
-    "## espace de travail / index / repo"
+    "## espace de travail / index / dépôt"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "lorsque vous créez un repo git **localement** sur votre ordi, vous disposez de trois éléments :\n",
+    "lorsque vous créez un dépôt git **localement** sur votre ordi, vous disposez de trois éléments :\n",
     "\n",
     "* un espace de travail: répertoires et fichiers\n",
     "* un index: changements en préparation pour le prochain commit\n",
@@ -348,7 +348,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![](media/repo-contents-1-three-parts.png)"
+    "![](media/dépôt-contents-1-three-parts.png)"
    ]
   },
   {
@@ -370,7 +370,7 @@
     }
    },
    "source": [
-    "## repo 'nu' *vs* repo de travail"
+    "## dépôt 'nu' *vs* dépôt de travail"
    ]
   },
   {
@@ -379,13 +379,13 @@
     "cell_style": "center"
    },
    "source": [
-    "* un repo 'usuel' contient donc trois parties\n",
+    "* un dépôt 'usuel' contient donc trois parties\n",
     "  * espace de travail\n",
     "  * index\n",
-    "  * repo à proprement parler\n",
-    "* un repo 'hébergé' \n",
+    "  * dépôt à proprement parler\n",
+    "* un dépôt 'hébergé' \n",
     "  * par ex. sur *github.com*\n",
-    "  * est dit nu (*bare repo*)"
+    "  * est dit nu (*bare dépôt*)"
    ]
   },
   {
@@ -396,9 +396,9 @@
     }
    },
    "source": [
-    "Un repo 'usuel' correspond au fait qu'un humain travaille sur le contenu des fichiers. On n'a besoin des parties 'espace de travail' et 'index' que pour travailler à de nouvelles modifications, et expérimenter avant de valider dans un commit. \n",
+    "Un dépôt 'usuel' correspond au fait qu'un humain travaille sur le contenu des fichiers. On n'a besoin des parties 'espace de travail' et 'index' que pour travailler à de nouvelles modifications, et expérimenter avant de valider dans un commit. \n",
     "\n",
-    "Par contre dans un repo distant comme par exemple sur github, seuls les commits sont importants, et on n'a pas besoin de l'index car on ne crée pas les commits par expérimentation; du coup on peut faire l'économie des composants bleu et vert, qui n'apportent que des inconvénients, et c'est pourquoi on a introduit la notion de repo nu."
+    "Par contre dans un dépôt distant comme par exemple sur github, seuls les commits sont importants, et on n'a pas besoin de l'index car on ne crée pas les commits par expérimentation; du coup on peut faire l'économie des composants bleu et vert, qui n'apportent que des inconvénients, et c'est pourquoi on a introduit la notion de dépôt nu."
    ]
   },
   {
@@ -409,7 +409,7 @@
     }
    },
    "source": [
-    "## zoom sur les repos"
+    "## zoom sur les dépôts"
    ]
   },
   {
@@ -433,7 +433,7 @@
     }
    },
    "source": [
-    "![](media/repo-contents-2-repo-sync-to-repo.png)"
+    "![](media/dépôt-contents-2-dépôt-sync-to-dépôt.png)"
    ]
   },
   {
@@ -455,7 +455,7 @@
    "source": [
     "**commandes *locales***\n",
     "\n",
-    "* ne se préoccupent pas d'un éventuel repo distant\n",
+    "* ne se préoccupent pas d'un éventuel dépôt distant\n",
     "\n",
     "* créer des commits\n",
     "  * `init`\n",
@@ -477,7 +477,7 @@
    "source": [
     "**commandes *distantes***\n",
     "\n",
-    "* pour se synchroniser avec un autre repo \n",
+    "* pour se synchroniser avec un autre dépôt \n",
     "\n",
     "* inspecter\n",
     "  * `fetch`\n",
@@ -545,7 +545,7 @@
     "Sous le capot, elle utilise naturellement le système `git` de manière totalement native.\n",
     "En supplément, elle offre des traits supplémentaires, dans une dimension que nous qualifions de *sociale*.\n",
     "\n",
-    "Les deux étages sont très largement indépendants; en allant sur github et en n'utilisant pas les traits additionnels, on reste libre de partir ensuite sur gitlab; même si ça ne présente pas un grand intérêt, pour bien comprendre, on peut même avoir le même repo présent à la fois sur github et gitlab."
+    "Les deux étages sont très largement indépendants; en allant sur github et en n'utilisant pas les traits additionnels, on reste libre de partir ensuite sur gitlab; même si ça ne présente pas un grand intérêt, pour bien comprendre, on peut même avoir le même dépôt présent à la fois sur github et gitlab."
    ]
   },
   {
@@ -560,12 +560,12 @@
     "\n",
     "* session 1\n",
     "  * primer   \n",
-    "    présenter le modèle mental repo / espace de travail / index  \n",
+    "    présenter le modèle mental dépôt / espace de travail / index  \n",
     "    bien utiliser git en local, commit / branches\n",
     "\n",
     "* session 2\n",
     "  * synchros  \n",
-    "    mettre à jour deux repos l'un par rapport à l'autre\n",
+    "    mettre à jour deux dépôts l'un par rapport à l'autre\n",
     "    un mot sur les plateformes : fork, pull request, …\n",
     "\n",
     "  * avancé   \n",

--- a/notebooks/2-01-my-first-repo.ipynb
+++ b/notebooks/2-01-my-first-repo.ipynb
@@ -37,10 +37,10 @@
     "## objectifs\n",
     "\n",
     "* utilisation **en local seulement** pour l'instant\n",
-    "* créer un dépôt / repo à partir de rien\n",
+    "* créer un dépôt / dépôt à partir de rien\n",
     "* créer quelques commits\n",
     "* illustrer le rôle de l'index dans la création d'un commit\n",
-    "* voir le contenu du repo"
+    "* voir le contenu du dépôt"
    ]
   },
   {
@@ -106,14 +106,14 @@
     }
    },
    "source": [
-    "## créer un repo git"
+    "## créer un dépôt git"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "la première commande à connaître est celle qui crée un repo vide:\n",
+    "la première commande à connaître est celle qui crée un dépôt vide:\n",
     "\n",
     "`git init`\n",
     "\n",
@@ -135,16 +135,16 @@
     "\n",
     "# pour pouvoir recommencer le scénario depuis le début\n",
     "# je nettoie complètement ce qu'on a pu faire précédemment\n",
-    "if [ -d my-first-repo ]; then\n",
+    "if [ -d my-first-dépôt ]; then\n",
     "    echo \"on repart d'un directory vide\"\n",
-    "    rm -rf my-first-repo\n",
+    "    rm -rf my-first-dépôt\n",
     "fi\n",
     "\n",
     "# on le crée\n",
-    "mkdir my-first-repo\n",
+    "mkdir my-first-dépôt\n",
     "\n",
     "# on va dedans\n",
-    "cd my-first-repo"
+    "cd my-first-dépôt"
    ]
   },
   {
@@ -155,7 +155,7 @@
     }
    },
    "source": [
-    "Il n'est pas important de comprendre cette cellule en profondeur, ce sont des détails qui nous permettent de rendre le scénario plus facilement rejouable. En substance ici, on s'assure simplement de repartir d'un répertoire vierge, qui s'appelle `my-first-repo` et qui est dans le répertoire des notebooks."
+    "Il n'est pas important de comprendre cette cellule en profondeur, ce sont des détails qui nous permettent de rendre le scénario plus facilement rejouable. En substance ici, on s'assure simplement de repartir d'un répertoire vierge, qui s'appelle `my-first-dépôt` et qui est dans le répertoire des notebooks."
    ]
   },
   {
@@ -199,7 +199,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## pour **transformer ce répertoire vide en repo git**"
+    "## pour **transformer ce répertoire vide en dépôt git**"
    ]
   },
   {
@@ -349,7 +349,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![](media/repo-contents-3-add-index-commit.png)"
+    "![](media/dépôt-contents-3-add-index-commit.png)"
    ]
   },
   {
@@ -800,7 +800,7 @@
     "\n",
     "40 caractères hexadécimaux, ça fait $40 * 4$ bits, donc $2^{160}$ hash différents; de l'ordre de $10^{50}$.\n",
     "\n",
-    "en général, seulement 7 caractères suffisent pour disambigüer les commits dans un repo; en effet il y a $2^{7*4} = 2^{28} = 268435456$  \n",
+    "en général, seulement 7 caractères suffisent pour disambigüer les commits dans un dépôt; en effet il y a $2^{7*4} = 2^{28} = 268435456$  \n",
     "suites de 7 digits hexadécimaux."
    ]
   },
@@ -1191,7 +1191,7 @@
    },
    "source": [
     "à ce stade de notre avancement, le repository possède une seule branche qui s'appelle `master`;  \n",
-    "c'est le nom par défaut, lorsqu'on crée un repo vide on se trouve sur la branche `master`\n",
+    "c'est le nom par défaut, lorsqu'on crée un dépôt vide on se trouve sur la branche `master`\n",
     "\n",
     "et donc naturellement, comme pour l'instant on n'a qu'une seule branche,\n",
     "c'est aussi la branche courante (`On branch master`)"
@@ -1288,7 +1288,7 @@
    },
    "source": [
     "à ce stade nous avons donc :  \n",
-    "deux fichiers dans le (dernier commit du) repo  \n",
+    "deux fichiers dans le (dernier commit du) dépôt  \n",
     "et 2 fichiers nouveaux (inconnus de git) "
    ]
   },
@@ -1323,7 +1323,7 @@
    "source": [
     "et deux commits\n",
     "\n",
-    "![](../media/repo-2c-1b.png)"
+    "![](../media/dépôt-2c-1b.png)"
    ]
   },
   {
@@ -1477,7 +1477,7 @@
     "# ici git status me montre que j'ai \n",
     "# (*) le fichier README.md modifié \n",
     "# (*) le fichier factorial.md\n",
-    "#     qui n'est pas dans le repo\n",
+    "#     qui n'est pas dans le dépôt\n",
     "git status"
    ]
   },
@@ -1546,7 +1546,7 @@
    "metadata": {},
    "source": [
     "pour rappel, ce qu'on avait observé après deux commits :\n",
-    "![](../media/repo-2c-1b.png)"
+    "![](../media/dépôt-2c-1b.png)"
    ]
   },
   {
@@ -1554,7 +1554,7 @@
    "metadata": {},
    "source": [
     "et maintenant\n",
-    "![](media/repo-4c-1b.png)"
+    "![](media/dépôt-4c-1b.png)"
    ]
   },
   {
@@ -1632,7 +1632,7 @@
    "source": [
     "le plus souvent, le workflow consiste pour vous à modifier les fichiers, et une fois que vous êtes satisfait, à ranger ces nouvelles versions des fichiers dans un commit - en passant par l'index.\n",
     "\n",
-    "    espace de travail → index → repo"
+    "    espace de travail → index → dépôt"
    ]
   },
   {
@@ -1653,7 +1653,7 @@
     " \n",
     "mais il faut bien comprendre, et le plus tôt sera le mieux, que dans certains cas, c'est l'**inverse qui se produit**\n",
     "\n",
-    "    repo -> espace de travail\n",
+    "    dépôt -> espace de travail\n",
     "\n",
     "par exemple:\n",
     "\n",
@@ -1876,12 +1876,12 @@
    "source": [
     "les points à retenir:\n",
     "\n",
-    "* on crée un repo local avec `git init`\n",
+    "* on crée un dépôt local avec `git init`\n",
     "* on crée un commit en deux temps:\n",
     "  * `git add` pour accumuler des changements dans le *stage* ou l'*index*\n",
     "  * `git commit` pour créer le commit\n",
     "  * le commit est créé le long de la branche courante\n",
-    "* un repo est essentiellement un ensemble de commits\n",
+    "* un dépôt est essentiellement un ensemble de commits\n",
     "  * liés entre eux par un graphe acyclique\n",
     "* un commit peut être identifié par\n",
     "  * le nom spécial `HEAD`\n",
@@ -1940,7 +1940,7 @@
    "name": "bash",
    "version": "0.2.1"
   },
-  "notebookname": "mon premier repo",
+  "notebookname": "mon premier dépôt",
   "rise": {
    "autolaunch": true,
    "slideNumber": "c/t",

--- a/notebooks/2-02-consistency-repo-fs.ipynb
+++ b/notebooks/2-02-consistency-repo-fs.ipynb
@@ -23,7 +23,7 @@
     }
    },
    "source": [
-    "# cohérence repo - fichiers"
+    "# cohérence dépôt - fichiers"
    ]
   },
   {
@@ -55,7 +55,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "si vous avez bien suivi et exécuté la 1ère partie, vous devez avoir un répertoire `my-first-repo` qui contient 4 commits."
+    "si vous avez bien suivi et exécuté la 1ère partie, vous devez avoir un répertoire `my-first-dépôt` qui contient 4 commits."
    ]
   },
   {
@@ -65,7 +65,7 @@
    "outputs": [],
    "source": [
     "# si nécessaire, vous pouvez remettre le repository \n",
-    "# dans l'état où il est après le notebook 10-my-first-repo\n",
+    "# dans l'état où il est après le notebook 10-my-first-dépôt\n",
     "# \n",
     "# pour cela mettez \"true\" au lieu de \"\"\n",
     "# et bien sûr évaluer la cellule\n",
@@ -74,7 +74,7 @@
     "\n",
     "if [ -n \"$reset\" ]; then \n",
     "    cd $TOP\n",
-    "    bash $SCRIPTS/2-01-my-first-repo.sh \n",
+    "    bash $SCRIPTS/2-01-my-first-dépôt.sh \n",
     "fi >& /dev/null"
    ]
   },
@@ -87,9 +87,9 @@
    },
    "source": [
     "Il n'est pas nécessaire de comprendre dans le détail le comportement de la première cellule sur ce slide. \n",
-    "Son propos est, lorsque c'est nécessaire, de pouvoir remettre le repo dans l'état attendu, c'est-à-dire celui dans lequel on l'a laissé à l'issue du notebook précédent. \n",
+    "Son propos est, lorsque c'est nécessaire, de pouvoir remettre le dépôt dans l'état attendu, c'est-à-dire celui dans lequel on l'a laissé à l'issue du notebook précédent. \n",
     "\n",
-    "Par défaut cette cellule ne fait rien; pour actionner cette possibilité et reinitialiser le repo, il suffit de modifier la définition de la variable `reset` pour faire `reset=\"true\"` (sans espaces), et naturellement d'évaluer la cellule."
+    "Par défaut cette cellule ne fait rien; pour actionner cette possibilité et reinitialiser le dépôt, il suffit de modifier la définition de la variable `reset` pour faire `reset=\"true\"` (sans espaces), et naturellement d'évaluer la cellule."
    ]
   },
   {
@@ -102,8 +102,8 @@
    },
    "outputs": [],
    "source": [
-    "# si nécessaire, on se place dans le repo git\n",
-    "[ -d my-first-repo ] && cd my-first-repo\n",
+    "# si nécessaire, on se place dans le dépôt git\n",
+    "[ -d my-first-dépôt ] && cd my-first-dépôt\n",
     "\n",
     "pwd"
    ]
@@ -255,7 +255,7 @@
     "cell_style": "center"
    },
    "source": [
-    "![](media/repo-4c-2b.png)"
+    "![](media/dépôt-4c-2b.png)"
    ]
   },
   {
@@ -268,7 +268,7 @@
    "source": [
     "Sans option, `git log` parcourt le graphe des commits à partir de la branche courante. Or les relations entre commits sont orientées, un commit a connaissance seulemnt des commits antérieurs - on en reparlera longuement. \n",
     "\n",
-    "Si bien qu'en partant de la branche courante `devel` on ne trouve que deux commits, alors qu'en partant de `master` on trouve bien les 4 commits présents dans le repo."
+    "Si bien qu'en partant de la branche courante `devel` on ne trouve que deux commits, alors qu'en partant de `master` on trouve bien les 4 commits présents dans le dépôt."
    ]
   },
   {
@@ -279,7 +279,7 @@
     }
    },
    "source": [
-    "## cohérence espace de travail / repo"
+    "## cohérence espace de travail / dépôt"
    ]
   },
   {
@@ -296,7 +296,7 @@
     "et bien entendu `git` **maintient la cohérence** entre \n",
     "\n",
     "* l'espace de travail (fichiers)\n",
-    "* le repo (commits)\n",
+    "* le dépôt (commits)\n",
     "* et accessoirement l'index"
    ]
   },
@@ -484,7 +484,7 @@
    "source": [
     "## état\n",
     "\n",
-    "l'état de notre repo à la fin de ce scénario"
+    "l'état de notre dépôt à la fin de ce scénario"
    ]
   },
   {
@@ -524,7 +524,7 @@
    "name": "bash",
    "version": "0.2.1"
   },
-  "notebookname": "cohérence repo - fichiers",
+  "notebookname": "cohérence dépôt - fichiers",
   "rise": {
    "autolaunch": true,
    "slideNumber": "c/t",

--- a/notebooks/2-03-my-first-merge.ipynb
+++ b/notebooks/2-03-my-first-merge.ipynb
@@ -56,7 +56,7 @@
    "metadata": {},
    "source": [
     "si vous avez bien suivi et exécuté ce qui précède,  \n",
-    "vous devez avoir un répertoire `my-first-repo`:\n",
+    "vous devez avoir un répertoire `my-first-dépôt`:\n",
     "\n",
     "* qui contient 4 commits\n",
     "* et deux branches `master` et `devel`\n",
@@ -78,8 +78,8 @@
     "\n",
     "if [ -n \"$reset\" ]; then \n",
     "    cd $TOP\n",
-    "    bash $SCRIPTS/2-01-my-first-repo.sh \n",
-    "    bash $SCRIPTS/2-02-consistency-repo-fs.sh \n",
+    "    bash $SCRIPTS/2-01-my-first-dépôt.sh \n",
+    "    bash $SCRIPTS/2-02-consistency-dépôt-fs.sh \n",
     "fi >& /dev/null"
    ]
   },
@@ -93,8 +93,8 @@
    },
    "outputs": [],
    "source": [
-    "# si nécessaire, on se place dans le repo git\n",
-    "[ -d my-first-repo ] && cd my-first-repo\n",
+    "# si nécessaire, on se place dans le dépôt git\n",
+    "[ -d my-first-dépôt ] && cd my-first-dépôt\n",
     "\n",
     "pwd"
    ]
@@ -156,7 +156,7 @@
     "cell_style": "split"
    },
    "source": [
-    "![](media/repo-4c-2b.png)"
+    "![](media/dépôt-4c-2b.png)"
    ]
   },
   {
@@ -230,7 +230,7 @@
     "cell_style": "split"
    },
    "source": [
-    "![](media/repo-5c-2b.png)"
+    "![](media/dépôt-5c-2b.png)"
    ]
   },
   {
@@ -354,7 +354,7 @@
     "cell_style": "split"
    },
    "source": [
-    "![](media/repo-5c-2b.png)"
+    "![](media/dépôt-5c-2b.png)"
    ]
   },
   {
@@ -885,7 +885,7 @@
    "source": [
     "## état\n",
     "\n",
-    "pour pouvoir s'y référer le cas échéant, voici notre repo à ce stade"
+    "pour pouvoir s'y référer le cas échéant, voici notre dépôt à ce stade"
    ]
   },
   {

--- a/notebooks/2-04-kinds-of-merge.ipynb
+++ b/notebooks/2-04-kinds-of-merge.ipynb
@@ -55,7 +55,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "si vous avez bien suivi et exécuté ce qui précède, vous devez avoir un répertoire `my-first-repo`:\n",
+    "si vous avez bien suivi et exécuté ce qui précède, vous devez avoir un répertoire `my-first-dépôt`:\n",
     "\n",
     "* qui contient 6 commits\n",
     "* et deux branches `master` et `devel`\n",
@@ -78,8 +78,8 @@
     "\n",
     "if [ -n \"$reset\" ]; then \n",
     "    cd $TOP\n",
-    "    bash $SCRIPTS/2-01-my-first-repo.sh\n",
-    "    bash $SCRIPTS/2-02-consistency-repo-fs.sh\n",
+    "    bash $SCRIPTS/2-01-my-first-dépôt.sh\n",
+    "    bash $SCRIPTS/2-02-consistency-dépôt-fs.sh\n",
     "    bash $SCRIPTS/2-03-my-first-merge.sh\n",
     "fi >& /dev/null"
    ]
@@ -101,8 +101,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# si nécessaire, on se place dans le repo git\n",
-    "[ -d my-first-repo ] && cd my-first-repo\n",
+    "# si nécessaire, on se place dans le dépôt git\n",
+    "[ -d my-first-dépôt ] && cd my-first-dépôt\n",
     "\n",
     "pwd"
    ]
@@ -772,7 +772,7 @@
     }
    },
    "source": [
-    "Le message d'échec peut paraître relativement sybillin ; en fait les détails de ce qui a réussi ou pas sont donnés à l'utilisateur au travers de l'état dans lequel le repo est laissé après le merge.\n",
+    "Le message d'échec peut paraître relativement sybillin ; en fait les détails de ce qui a réussi ou pas sont donnés à l'utilisateur au travers de l'état dans lequel le dépôt est laissé après le merge.\n",
     "\n",
     "**à noter** : dans ce cas de figure on pourrait revenir à la situation avant le merge en faisant `git merge --abort`"
    ]

--- a/notebooks/2-05-order-reachable.ipynb
+++ b/notebooks/2-05-order-reachable.ipynb
@@ -70,8 +70,8 @@
     "\n",
     "if [ -n \"$reset\" ]; then \n",
     "    cd $TOP\n",
-    "    bash $SCRIPTS/2-01-my-first-repo.sh\n",
-    "    bash $SCRIPTS/2-02-consistency-repo-fs.sh\n",
+    "    bash $SCRIPTS/2-01-my-first-dépôt.sh\n",
+    "    bash $SCRIPTS/2-02-consistency-dépôt-fs.sh\n",
     "    bash $SCRIPTS/2-03-my-first-merge.sh\n",
     "    bash $SCRIPTS/2-04-kinds-of-merge.sh\n",
     "fi >& /dev/null"
@@ -94,8 +94,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# si nécessaire, on se place dans le repo git\n",
-    "[ -d my-first-repo ] && cd my-first-repo\n",
+    "# si nécessaire, on se place dans le dépôt git\n",
+    "[ -d my-first-dépôt ] && cd my-first-dépôt\n",
     "\n",
     "pwd"
    ]
@@ -345,7 +345,7 @@
    "source": [
     "Nous étudierons plus en détail le comportement de `git reset` dans une section ultérieure; ici avec l'option `--hard`, son effet est de faire reculer d'un cran - parce que `HEAD^` - la branche courante, et de remettre les fichiers dans l'état de ce commit.\n",
     "\n",
-    "Lorsqu'un commit - comme ici *conflit résolu*) n'est plus atteignable à partir des branches connues, on peut avoir l'impression qu'il a été supprimé; ce n'est pas le cas en réalité - en tous cas pas immédiatement - il existe toujours dans le repo, mais on ne peut plus y faire référence que au travers de son SHA-1."
+    "Lorsqu'un commit - comme ici *conflit résolu*) n'est plus atteignable à partir des branches connues, on peut avoir l'impression qu'il a été supprimé; ce n'est pas le cas en réalité - en tous cas pas immédiatement - il existe toujours dans le dépôt, mais on ne peut plus y faire référence que au travers de son SHA-1."
    ]
   },
   {
@@ -908,11 +908,11 @@
     "* le lien dans l'autre sens n'est **pas matérialisé**  \n",
     "  dans un commit (car immutable)\n",
     "\n",
-    "* la partie \"visible\" ou \"atteignable\" du repo est ce qu'on peut  \n",
+    "* la partie \"visible\" ou \"atteignable\" du dépôt est ce qu'on peut  \n",
     "  atteindre **depuis le commit courant et des branches connues**\n",
     "\n",
     "* lorsqu'un commit n'est plus atteignable\n",
-    "  * il est toujours dans le repo (au - quelques jours)\n",
+    "  * il est toujours dans le dépôt (au - quelques jours)\n",
     "  * mais il faut son sha-1 pour y accéder"
    ]
   },

--- a/notebooks/3-01-my-first-remote.ipynb
+++ b/notebooks/3-01-my-first-remote.ipynb
@@ -73,11 +73,11 @@
     }
    },
    "source": [
-    "Tout ce qui a été vu jusqu'à présent était **local** à un repo.\n",
+    "Tout ce qui a été vu jusqu'à présent était **local** à un dépôt.\n",
     "\n",
     "Dans cette partie du cours nous allons étudier les outils qui permettent de synchroniser les repos entre eux, c'est-à-dire de matérialiser les flêches du schéma.\n",
     "\n",
-    "On rappelle également que les boites gris clair représentent un repo *bare* - c'est-à-dire sans espace de travail associé, simplement le graphe des commits. C'est le cas typiquement pour les plateformes de type github."
+    "On rappelle également que les boites gris clair représentent un dépôt *bare* - c'est-à-dire sans espace de travail associé, simplement le graphe des commits. C'est le cas typiquement pour les plateformes de type github."
    ]
   },
   {
@@ -97,8 +97,8 @@
    "source": [
     "pour cette partie :\n",
     "\n",
-    "* nous repartons d'un repo quasiment vide `repo-alice`\n",
-    "* que l'on va *cloner* dans `repo-cloned`\n",
+    "* nous repartons d'un dépôt quasiment vide `dépôt-alice`\n",
+    "* que l'on va *cloner* dans `dépôt-cloned`\n",
     "* puis les modifier (créer des commits)\n",
     "* et les synchroniser entre eux "
    ]
@@ -111,7 +111,7 @@
     }
    },
    "source": [
-    "En pratique quand deux personnes travaillent ensemble, elles passent la plupart du temps au travers d'un troisième repo sur une infrastructure publique de type github. Mais pour l'instant on s'attache à bien comprendre les mécanismes de synchronisation entre deux repos."
+    "En pratique quand deux personnes travaillent ensemble, elles passent la plupart du temps au travers d'un troisième dépôt sur une infrastructure publique de type github. Mais pour l'instant on s'attache à bien comprendre les mécanismes de synchronisation entre deux repos."
    ]
   },
   {
@@ -126,18 +126,18 @@
    "source": [
     "cd $TOP\n",
     "\n",
-    "# on recommence un autre repo plus simple; à nouveau\n",
+    "# on recommence un autre dépôt plus simple; à nouveau\n",
     "# je nettoie complètement ce qu'on a pu faire précédemment\n",
-    "if [ -d repo-alice ]; then\n",
+    "if [ -d dépôt-alice ]; then\n",
     "    echo \"on repart d'un directory vide\"\n",
-    "    rm -rf repo-alice repo-cloned fake-github.git repo-bob\n",
+    "    rm -rf dépôt-alice dépôt-cloned fake-github.git dépôt-bob\n",
     "fi\n",
     "\n",
     "# on le crée\n",
-    "mkdir repo-alice\n",
+    "mkdir dépôt-alice\n",
     "\n",
     "# on va dedans\n",
-    "cd repo-alice"
+    "cd dépôt-alice"
    ]
   },
   {
@@ -146,8 +146,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# si nécessaire, on se place dans le repo git\n",
-    "[ -d repo-alice ] && cd repo-alice\n",
+    "# si nécessaire, on se place dans le dépôt git\n",
+    "[ -d dépôt-alice ] && cd dépôt-alice\n",
     "\n",
     "pwd"
    ]
@@ -169,7 +169,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "$SCRIPTS/do populate-repo-alice"
+    "$SCRIPTS/do populate-dépôt-alice"
    ]
   },
   {
@@ -236,7 +236,7 @@
    "metadata": {},
    "source": [
     "* en général, les repos sont créés sur des **machines distinctes**\n",
-    "  * typiquement : un repo local + un sur github\n",
+    "  * typiquement : un dépôt local + un sur github\n",
     "* techniquement, pas obligatoire\n",
     "  * **pour les besoins du cours**,  \n",
     "    nous allons créer nos repos **localement** \n",
@@ -255,16 +255,16 @@
    },
    "outputs": [],
    "source": [
-    "# on utilisera ce répertoire $TOP/repo-cloned\n",
-    "# pour simuler un deuxième repo\n",
+    "# on utilisera ce répertoire $TOP/dépôt-cloned\n",
+    "# pour simuler un deuxième dépôt\n",
     "# \n",
     "# on verra plus tard qu'en pratique deux personnes\n",
     "# qui travaillent ensemble passent par un troisième \n",
-    "# repo sur github, mais pour l'instant on veut \n",
+    "# dépôt sur github, mais pour l'instant on veut \n",
     "# seulement bien illustrer les fonctions `fetch` et `pull` \n",
     "\n",
-    "if [ -d $TOP/repo-cloned ]; then\n",
-    "    rm -rf $TOP/repo-cloned\n",
+    "if [ -d $TOP/dépôt-cloned ]; then\n",
+    "    rm -rf $TOP/dépôt-cloned\n",
     "fi"
    ]
   },
@@ -276,7 +276,7 @@
     }
    },
    "source": [
-    "## `git clone` pour dupliquer un repo"
+    "## `git clone` pour dupliquer un dépôt"
    ]
   },
   {
@@ -292,7 +292,7 @@
    "source": [
     "cd $TOP\n",
     "\n",
-    "git clone repo-alice repo-cloned"
+    "git clone dépôt-alice dépôt-cloned"
    ]
   },
   {
@@ -303,7 +303,7 @@
    },
    "outputs": [],
    "source": [
-    "cd $TOP/repo-cloned\n",
+    "cd $TOP/dépôt-cloned\n",
     "\n",
     "ls"
    ]
@@ -316,7 +316,7 @@
     }
    },
    "source": [
-    "Une petite subtilité à noter ici : dans cette configuration les deux repos - source et destination - sont des repo *avec fichiers* - et donc pas *bare*. On pourra ainsi montrer la totale symétrie des outils de synchronisation, il n'y a aucune notion de maitre ou d'esclave lorsque deux repos ont une relation de synchronisation.\n",
+    "Une petite subtilité à noter ici : dans cette configuration les deux repos - source et destination - sont des dépôt *avec fichiers* - et donc pas *bare*. On pourra ainsi montrer la totale symétrie des outils de synchronisation, il n'y a aucune notion de maitre ou d'esclave lorsque deux repos ont une relation de synchronisation.\n",
     "\n",
     "On verra dans un deuxième exemple le cas où un des repos est *bare*, ce qui est plus conforme à ce qui se passe en général en pratique, puisqu'à nouveau les repos de type github sont des repos *bare* sans espace de travail."
    ]
@@ -335,7 +335,7 @@
     "* **les commits**, c'est-à-dire la partie `bare`\n",
     "* les fichiers présents dans le **commit courant**\n",
     "* mais par contre l'index n'est **pas concerné**\n",
-    "  * si on avait eu des modifications pendantes dans `repo-alice`\n",
+    "  * si on avait eu des modifications pendantes dans `dépôt-alice`\n",
     "  * que ce soit dans l'index ou les fichiers\n",
     "  * ils **n'auraient pas** été copiés"
    ]
@@ -370,10 +370,10 @@
     }
    },
    "source": [
-    "Remarquez également que `repo-cloned` ne contient pas de branche locale `master`.\n",
-    "En fait au moment du `git clone`,  la branche courante de `repo-alice` était `devel`, aussi le clone a créé dans `repo-cloned` une branche `devel`, mais pas de branche `master`.\n",
+    "Remarquez également que `dépôt-cloned` ne contient pas de branche locale `master`.\n",
+    "En fait au moment du `git clone`,  la branche courante de `dépôt-alice` était `devel`, aussi le clone a créé dans `dépôt-cloned` une branche `devel`, mais pas de branche `master`.\n",
     "\n",
-    "À ce stade si on voulait travailler sur la branche `master` dans `repo-cloned`, on pourrait le faire facilement en faisant simplement `git checkout master`."
+    "À ce stade si on voulait travailler sur la branche `master` dans `dépôt-cloned`, on pourrait le faire facilement en faisant simplement `git checkout master`."
    ]
   },
   {
@@ -385,17 +385,17 @@
    },
    "source": [
     "* en réalité dans un `git clone`\n",
-    "  * du coté source, seul le ***bare repo*** est lu\n",
+    "  * du coté source, seul le ***bare dépôt*** est lu\n",
     "  * les fichiers et l'index ne sont **pas du tout regardés**\n",
     "  * bien souvent d'ailleurs la source est sur une infra comme github\n",
-    "  * et dans ce cas la source n'est **que** un *bare repo*\n",
+    "  * et dans ce cas la source n'est **que** un *bare dépôt*\n",
     "  \n",
     "* les fonctions de synchro entre repos\n",
     "  * ne concernent en réalité  \n",
-    "    que la partie 'bare repo' des deux cotés\n",
+    "    que la partie 'bare dépôt' des deux cotés\n",
     "\n",
     "  * en général les fichiers et index **ne sont pas concernés**  \n",
-    "    par les synchros entre repo\n",
+    "    par les synchros entre dépôt\n",
     "\n",
     "  * qui ne font principalement que transférer des commits  \n",
     "    (et mettre à jour des branches)\n",
@@ -413,10 +413,10 @@
     }
    },
    "source": [
-    "En fait les fichiers présents dans le repo source ne sont pas du tout lus lors du `clone`.\n",
-    "La seule chose qui est copiée lorsqu'on fait un `clone` provient du `.git` du repo source, on aurait pu aussi bien cloner un repo *bare*.\n",
+    "En fait les fichiers présents dans le dépôt source ne sont pas du tout lus lors du `clone`.\n",
+    "La seule chose qui est copiée lorsqu'on fait un `clone` provient du `.git` du dépôt source, on aurait pu aussi bien cloner un dépôt *bare*.\n",
     "\n",
-    "Les fichiers qui sont ensuite créés dans le repo destination le sont uniquement sur la base du commit courant."
+    "Les fichiers qui sont ensuite créés dans le dépôt destination le sont uniquement sur la base du commit courant."
    ]
   },
   {
@@ -435,7 +435,7 @@
     "* la seule différence bien sûr ce sont les droits d'accès\n",
     "  * en gros c'est **chacun chez soi**\n",
     "  * si vous avez les droits d'accès (linux, windows, macOS)  \n",
-    "    sur un repo vous pouvez écrire dedans"
+    "    sur un dépôt vous pouvez écrire dedans"
    ]
   },
   {
@@ -451,8 +451,8 @@
     "* les SHA1 des commits **sont préservés**\n",
     "* la copie se fait quasiment à l'octet près\n",
     "* ce qui permet un mode de réplication incrémental\n",
-    "  * si je copie un gros repo un lundi\n",
-    "  * et que je tire depuis ce repo mardi\n",
+    "  * si je copie un gros dépôt un lundi\n",
+    "  * et que je tire depuis ce dépôt mardi\n",
     "  * on va efficacement calculer ce qu'il est réellement utile de transférer"
    ]
   },
@@ -464,7 +464,7 @@
    },
    "outputs": [],
    "source": [
-    "cd $TOP/repo-alice\n",
+    "cd $TOP/dépôt-alice\n",
     "git l -1"
    ]
   },
@@ -476,7 +476,7 @@
    },
    "outputs": [],
    "source": [
-    "cd $TOP/repo-cloned\n",
+    "cd $TOP/dépôt-cloned\n",
     "git l -1"
    ]
   },
@@ -496,7 +496,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "l'usage le plus fréquent consiste à dupliquer un repo qui est publié sur `github`\n",
+    "l'usage le plus fréquent consiste à dupliquer un dépôt qui est publié sur `github`\n",
     "\n",
     "par exemple ce cours est sur\n",
     "https://github.com/flotpython/gittutorial/"
@@ -567,11 +567,11 @@
    "source": [
     "**passif**\n",
     "\n",
-    "* `fetch`  injecte des commits distants dans le repo local **sans impact local**\n",
+    "* `fetch`  injecte des commits distants dans le dépôt local **sans impact local**\n",
     "\n",
     "**actif**\n",
     "\n",
-    "* `push`: injecte des commits locaux dans le repo distant\n",
+    "* `push`: injecte des commits locaux dans le dépôt distant\n",
     "* `pull` = `fetch`+`merge`\n"
    ]
   },
@@ -607,7 +607,7 @@
     "un *remote*, c'est \n",
     "\n",
     "* essentiellement **un nom** symbolique\n",
-    "* qui nous permet de faire facilement référence à un **autre repo**\n",
+    "* qui nous permet de faire facilement référence à un **autre dépôt**\n",
     "* i.e. plutôt que de retaper **son URL** à chaque fois"
    ]
   },
@@ -619,7 +619,7 @@
     }
    },
    "source": [
-    "En toute rigueur la notion de remote est une simple commodité, qui permet de ne pas avoir à retaper - et donc à se souvenir - du détail de l'URL qui permet d'accéder à un repo distant. "
+    "En toute rigueur la notion de remote est une simple commodité, qui permet de ne pas avoir à retaper - et donc à se souvenir - du détail de l'URL qui permet d'accéder à un dépôt distant. "
    ]
   },
   {
@@ -674,7 +674,7 @@
    "source": [
     "au moment du `clone`, git a créé pour nous ce *remote*  \n",
     "avec le nom prédéfini `origin`,  \n",
-    "qui désigne le repo d'où on a cloné"
+    "qui désigne le dépôt d'où on a cloné"
    ]
   },
   {
@@ -717,7 +717,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "un repo git est *self-contained*\n",
+    "un dépôt git est *self-contained*\n",
     "\n",
     "* toutes les références (branche et remote) sont des **objets locaux**\n",
     "* on peut **toujours** travailler sans connexion réseau\n",
@@ -725,10 +725,10 @@
     "pour résumer, deux notions très différentes\n",
     "\n",
     "* la branche désigne un point dans les commits (forcément locaux)\n",
-    "* le remote est simplement une **référence** vers un autre repo\n",
-    "  * c'est juste un nom, un alias, vers un autre repo\n",
+    "* le remote est simplement une **référence** vers un autre dépôt\n",
+    "  * c'est juste un nom, un alias, vers un autre dépôt\n",
     "* ainsi par exemple\n",
-    "  * on peut sans souci créer un remote vers un repo inexistant\n",
+    "  * on peut sans souci créer un remote vers un dépôt inexistant\n",
     "  * c'est seulement quand on s'en sert - via fetch/push/pull - qu'on se rendra compte du problème"
    ]
   },
@@ -747,7 +747,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "comme un repo est *self-contained*\n",
+    "comme un dépôt est *self-contained*\n",
     "\n",
     "* il conserve **localement** la trace des branches distantes\n",
     "* voyez par exemple les branches `origin/master` et `origin/devel`\n"
@@ -774,8 +774,8 @@
    "source": [
     "qu'on pourrait paraphraser comme ceci :\n",
     "\n",
-    "* du point de vue du repo `repo-cloned`\n",
-    "* il y a dans le repo distant `origin` (donc, `repo-alice`)\n",
+    "* du point de vue du dépôt `dépôt-cloned`\n",
+    "* il y a dans le dépôt distant `origin` (donc, `dépôt-alice`)\n",
     "* une branche `master` \n",
     "* qui pointe vers ce commit"
    ]
@@ -799,9 +799,9 @@
     "\n",
     "on va le voir tout de suite : \n",
     "\n",
-    "* si je crée dans `repo-alice` un commit\n",
+    "* si je crée dans `dépôt-alice` un commit\n",
     "  * c'est une opération **strictement locale**\n",
-    "* le clone `repo-cloned` n'en n'est pas informé immédiatement\n",
+    "* le clone `dépôt-cloned` n'en n'est pas informé immédiatement\n",
     "  * à nouveau, c'est du pair à pair / chacun chez soi\n",
     "* il le sera essentiellement s'il fait un `fetch`"
    ]
@@ -826,7 +826,7 @@
     }
    },
    "source": [
-    "Notez également que la plupart des interfaces graphiques, comme SourceTree ou GitKraken, font automatiquement un `fetch` à intervalles réguliers, typiquement toutes les 5 minutes, auprès des remotes connus de votre repo, ce qui est très commode pour être averti des autres contributions."
+    "Notez également que la plupart des interfaces graphiques, comme SourceTree ou GitKraken, font automatiquement un `fetch` à intervalles réguliers, typiquement toutes les 5 minutes, auprès des remotes connus de votre dépôt, ce qui est très commode pour être averti des autres contributions."
    ]
   },
   {
@@ -846,9 +846,9 @@
    "source": [
     "notre scénario\n",
     "\n",
-    "* créer un nouveau commit dans le repo originel `repo-alice`\n",
+    "* créer un nouveau commit dans le dépôt originel `dépôt-alice`\n",
     "* observer les deux repos à ce stade\n",
-    "* déclencher un `fetch` depuis `repo-cloned`\n",
+    "* déclencher un `fetch` depuis `dépôt-cloned`\n",
     "* observer les deux repos à ce stade"
    ]
   },
@@ -869,7 +869,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cd $TOP/repo-alice\n",
+    "cd $TOP/dépôt-alice\n",
     "$SCRIPTS/do first-commit-in-alice"
    ]
   },
@@ -890,7 +890,7 @@
     }
    },
    "source": [
-    "On crée un commit du coté du repo d'alice; peu importe son contenu à ce stade."
+    "On crée un commit du coté du dépôt d'alice; peu importe son contenu à ce stade."
    ]
   },
   {
@@ -912,7 +912,7 @@
    },
    "outputs": [],
    "source": [
-    "cd $TOP/repo-alice\n",
+    "cd $TOP/dépôt-alice\n",
     "git l"
    ]
   },
@@ -924,7 +924,7 @@
    },
    "outputs": [],
    "source": [
-    "cd $TOP/repo-cloned\n",
+    "cd $TOP/dépôt-cloned\n",
     "git l"
    ]
   },
@@ -946,11 +946,11 @@
    "outputs": [],
    "source": [
     "# je retourne sur le clone\n",
-    "cd $TOP/repo-cloned\n",
+    "cd $TOP/dépôt-cloned\n",
     "\n",
     "# on va chercher les commits nouveaux\n",
     "# en faisant --all on va sur tous les remote connus\n",
-    "# ici on n'en a qu'un, c'est origin = repo-alice\n",
+    "# ici on n'en a qu'un, c'est origin = dépôt-alice\n",
     "git fetch --all"
    ]
   },
@@ -984,9 +984,9 @@
    },
    "outputs": [],
    "source": [
-    "# le repo initial\n",
+    "# le dépôt initial\n",
     "\n",
-    "cd $TOP/repo-alice\n",
+    "cd $TOP/dépôt-alice\n",
     "git l"
    ]
   },
@@ -998,8 +998,8 @@
    },
    "outputs": [],
    "source": [
-    "# le repo après fetch\n",
-    "cd $TOP/repo-cloned\n",
+    "# le dépôt après fetch\n",
+    "cd $TOP/dépôt-cloned\n",
     "\n",
     "# si je ne précise pas --all\n",
     "# on part comme toujours de HEAD\n",
@@ -1049,7 +1049,7 @@
     "cell_style": "split"
    },
    "source": [
-    "à ce stade, pour me mettre à jour par rapport au repo distant, je peux\n",
+    "à ce stade, pour me mettre à jour par rapport au dépôt distant, je peux\n",
     "\n",
     "* merger `origin/devel` dans `devel`\n",
     "* ce qui ferait avancer `devel` d'un cran \n",
@@ -1268,7 +1268,7 @@
     "\n",
     "* le modèle étant symétrique (pair à pair)\n",
     "* à première vue, on se dit que le *push* \n",
-    "* c-à-d propager des commits locaux vers un repo distant\n",
+    "* c-à-d propager des commits locaux vers un dépôt distant\n",
     "* **devrait** être l'**exact symétrique** du *pull*\n"
    ]
   },
@@ -1282,8 +1282,8 @@
    },
    "source": [
     "* en pratique ce n'est **pas le cas**\n",
-    "* on travaille dans un **autre repo**\n",
-    "* d'ailleurs le plus souvent un *bare repo*"
+    "* on travaille dans un **autre dépôt**\n",
+    "* d'ailleurs le plus souvent un *bare dépôt*"
    ]
   },
   {
@@ -1333,9 +1333,9 @@
    "source": [
     "notez aussi que, bien entendu, lors d'un push :\n",
     "\n",
-    "* il faut les **droits d'écriture** dans le repo distant\n",
+    "* il faut les **droits d'écriture** dans le dépôt distant\n",
     "\n",
-    "dans le cas d'un repo distant sur github (gitlab, ...)\n",
+    "dans le cas d'un dépôt distant sur github (gitlab, ...)\n",
     "\n",
     "* il faut faire une démarche particulière pour obtenir ce droit\n",
     "* **ou bien** se créer un *fork* (c'est leur principale raison d'être)\n",
@@ -1365,14 +1365,14 @@
     "\n",
     "en pratique le `push` est utilisé pour\n",
     "\n",
-    "* exposer un travail sur un repo public - toujours *bare*\n",
+    "* exposer un travail sur un dépôt public - toujours *bare*\n",
     "* de façon à ce que les collaborateurs  \n",
-    "  puissent alors l'importer dans leur repo avec un `pull`\n",
+    "  puissent alors l'importer dans leur dépôt avec un `pull`\n",
     "  \n",
     "d'ailleurs \n",
     "\n",
     "* `git push` **se plaint** si on essaie de pousser  \n",
-    "  vers un **repo qui n'est pas *bare***\n"
+    "  vers un **dépôt qui n'est pas *bare***\n"
    ]
   },
   {
@@ -1383,9 +1383,9 @@
     }
    },
    "source": [
-    "La logique à l'oeuvre ici est qu'un repo qui est *bare* ne peut pas servir à créer de nouveaux commits - puisqu'il n'y a ni index ni espace de travail; c'est raisonnable de pouvoir pousser sur un tel repo, et en fait c'est un peu le seul intérêt d'un repo *bare*.\n",
+    "La logique à l'oeuvre ici est qu'un dépôt qui est *bare* ne peut pas servir à créer de nouveaux commits - puisqu'il n'y a ni index ni espace de travail; c'est raisonnable de pouvoir pousser sur un tel dépôt, et en fait c'est un peu le seul intérêt d'un dépôt *bare*.\n",
     "\n",
-    "Par contre un repo usuel, non *bare*, est utilisé par un humain pour travailler; du coup c'est plutôt à cette personne de tirer - et de gérer les éventuels conflits - qu'à un tiers de pousser."
+    "Par contre un dépôt usuel, non *bare*, est utilisé par un humain pour travailler; du coup c'est plutôt à cette personne de tirer - et de gérer les éventuels conflits - qu'à un tiers de pousser."
    ]
   },
   {
@@ -1404,9 +1404,9 @@
    "metadata": {},
    "source": [
     "* nous allons revoir du coup notre setup\n",
-    "* on conserve `repo-alice`\n",
-    "* on détruit `repo-cloned`\n",
-    "* on crée à la place un repo *bare* qui s'appelle `fake-github.git`\n",
+    "* on conserve `dépôt-alice`\n",
+    "* on détruit `dépôt-cloned`\n",
+    "* on crée à la place un dépôt *bare* qui s'appelle `fake-github.git`\n",
     "* on va voir tout de suite pourquoi ce nom en `.git`"
    ]
   },
@@ -1421,11 +1421,11 @@
    "outputs": [],
    "source": [
     "cd $TOP\n",
-    "rm -rf repo-cloned fake-github.git\n",
+    "rm -rf dépôt-cloned fake-github.git\n",
     "\n",
-    "# avec l'option --bare on crée un repo bare\n",
+    "# avec l'option --bare on crée un dépôt bare\n",
     "# comme il le serait sur github\n",
-    "git clone --bare repo-alice fake-github.git"
+    "git clone --bare dépôt-alice fake-github.git"
    ]
   },
   {
@@ -1437,7 +1437,7 @@
     }
    },
    "source": [
-    "## un *bare* repo"
+    "## un *bare* dépôt"
    ]
   },
   {
@@ -1457,7 +1457,7 @@
    "source": [
     "cd $TOP\n",
     "\n",
-    "# le contenu d'un repo bare\n",
+    "# le contenu d'un dépôt bare\n",
     "ls fake-github.git"
    ]
   },
@@ -1470,9 +1470,9 @@
    "outputs": [],
    "source": [
     "# est proche du contenu d'un .git\n",
-    "# dans un repo 'normal'\n",
+    "# dans un dépôt 'normal'\n",
     "\n",
-    "ls repo-alice/.git"
+    "ls dépôt-alice/.git"
    ]
   },
   {
@@ -1485,7 +1485,7 @@
     "* `objects`: c'est là que sont rangés les commits et leurs contenus\n",
     "* `refs`: c'est là que sont rangées les branches\n",
     "\n",
-    "on a l'habitude d'appeler les *bare* repo  \n",
+    "on a l'habitude d'appeler les *bare* dépôt  \n",
     "avec un nom en `.git` pour indiquer leur type (juste une convention)"
    ]
   },
@@ -1510,7 +1510,7 @@
    "source": [
     "scénario #1 : un push qui se passe bien\n",
     "\n",
-    "* je crée un commit dans le repo original\n",
+    "* je crée un commit dans le dépôt original\n",
     "* je le pousse sur le faux github"
    ]
   },
@@ -1535,7 +1535,7 @@
    "source": [
     "# créons un commit chez alice\n",
     "\n",
-    "cd $TOP/repo-alice\n",
+    "cd $TOP/dépôt-alice\n",
     "\n",
     "$SCRIPTS/do commit-in-initial-for-simple-push\n",
     "\n",
@@ -1601,13 +1601,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cd $TOP/repo-alice\n",
+    "cd $TOP/dépôt-alice\n",
     "\n",
     "# on avait bien un remote dans le scénario précédent\n",
-    "# mais c'était dans repo-cloned \n",
+    "# mais c'était dans dépôt-cloned \n",
     "# le remote avait alors été créé par 'git clone' \n",
     "# \n",
-    "# ici dans repo-alice on ne connait aucun remote\n",
+    "# ici dans dépôt-alice on ne connait aucun remote\n",
     " \n",
     "git remote"
    ]
@@ -1659,7 +1659,7 @@
     "# la situation dans initial\n",
     "# on a 4 commits\n",
     "\n",
-    "cd $TOP/repo-alice\n",
+    "cd $TOP/dépôt-alice\n",
     "\n",
     "git l --all"
    ]
@@ -1697,9 +1697,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# on se met dans le repo initial\n",
+    "# on se met dans le dépôt initial\n",
     "\n",
-    "cd $TOP/repo-alice\n",
+    "cd $TOP/dépôt-alice\n",
     "\n",
     "# la syntaxe de push est voisine de celle de pull\n",
     "# on pourrait faire simplement\n",
@@ -1742,7 +1742,7 @@
     "\n",
     "\n",
     "\n",
-    "cd $TOP/repo-alice\n",
+    "cd $TOP/dépôt-alice\n",
     "git l "
    ]
   },
@@ -1778,11 +1778,11 @@
     "nous avons à présent tous les éléments pour construire  \n",
     "le plus simple travail collaboratif :\n",
     "\n",
-    "* alice crée un repo local sur son laptop\n",
+    "* alice crée un dépôt local sur son laptop\n",
     "* elle travaille un moment seule, crée des commits\n",
-    "* elle publie son repo sur gihub\n",
-    "  * création d'un repo via l'interface web\n",
-    "  * ajout d'un remote dans son repo local\n",
+    "* elle publie son dépôt sur gihub\n",
+    "  * création d'un dépôt via l'interface web\n",
+    "  * ajout d'un remote dans son dépôt local\n",
     "  * push\n",
     "* bob peut alors créer un clone sur son laptop\n",
     "  * et si alice lui donne les droits d'écriture  \n",
@@ -1810,27 +1810,27 @@
    },
    "outputs": [],
    "source": [
-    "# on repart d'un repo tout simple avec seulement deux commits \n",
+    "# on repart d'un dépôt tout simple avec seulement deux commits \n",
     "# pour ne pas encombrer inutilement l'affichage\n",
     "\n",
     "# on nettoie\n",
     "cd $TOP\n",
-    "rm -rf repo-alice fake-github.git repo-bob\n",
+    "rm -rf dépôt-alice fake-github.git dépôt-bob\n",
     "\n",
-    "# recrée repo-alice avec deux commits\n",
+    "# recrée dépôt-alice avec deux commits\n",
     "cd $TOP\n",
-    "mkdir repo-alice\n",
-    "cd repo-alice\n",
-    "$SCRIPTS/do populate-repo-alice > /dev/null\n",
+    "mkdir dépôt-alice\n",
+    "cd dépôt-alice\n",
+    "$SCRIPTS/do populate-dépôt-alice > /dev/null\n",
     "\n",
-    "# on crée un repo bare qui remplace github\n",
+    "# on crée un dépôt bare qui remplace github\n",
     "# pour faire le proxy entre les deux acteurs\n",
     "cd $TOP\n",
-    "git clone --bare repo-alice fake-github.git\n",
+    "git clone --bare dépôt-alice fake-github.git\n",
     "\n",
-    "# on clone le faux github dans repo-bob\n",
+    "# on clone le faux github dans dépôt-bob\n",
     "cd $TOP\n",
-    "git clone fake-github.git repo-bob"
+    "git clone fake-github.git dépôt-bob"
    ]
   },
   {
@@ -1853,7 +1853,7 @@
    },
    "outputs": [],
    "source": [
-    "cd $TOP/repo-alice\n",
+    "cd $TOP/dépôt-alice\n",
     "git l"
    ]
   },
@@ -1877,7 +1877,7 @@
    },
    "outputs": [],
    "source": [
-    "cd $TOP/repo-bob\n",
+    "cd $TOP/dépôt-bob\n",
     "git l"
    ]
   },
@@ -1937,7 +1937,7 @@
    "source": [
     "# alice avance de son coté\n",
     "\n",
-    "cd $TOP/repo-alice\n",
+    "cd $TOP/dépôt-alice\n",
     "$SCRIPTS/do commit-alice\n",
     "\n",
     "git l"
@@ -1956,7 +1956,7 @@
    "source": [
     "# bob aussi\n",
     "\n",
-    "cd $TOP/repo-bob\n",
+    "cd $TOP/dépôt-bob\n",
     "$SCRIPTS/do commit-bob\n",
     "\n",
     "git l"
@@ -1987,7 +1987,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cd $TOP/repo-alice\n",
+    "cd $TOP/dépôt-alice\n",
     "git remote add github $TOP/fake-github.git\n",
     "git remote"
    ]
@@ -1998,7 +1998,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cd $TOP/repo-bob\n",
+    "cd $TOP/dépôt-bob\n",
     "git remote add github $TOP/fake-github.git\n",
     "git remote"
    ]
@@ -2029,7 +2029,7 @@
    },
    "outputs": [],
    "source": [
-    "cd $TOP/repo-alice\n",
+    "cd $TOP/dépôt-alice\n",
     "\n",
     "git push github devel:devel "
    ]
@@ -2117,7 +2117,7 @@
     "# notez bien qu'ici les deux modifications de alice et bob\n",
     "# sont indépendantes et peuvent être mergées sans conflit !\n",
     "\n",
-    "cd $TOP/repo-bob\n",
+    "cd $TOP/dépôt-bob\n",
     "git push github devel"
    ]
   },
@@ -2144,7 +2144,7 @@
     "# pour des raisons sordides liées au fait qu'on est dans un notebook\n",
     "# je lui passe l'option --no-edit\n",
     "\n",
-    "cd $TOP/repo-bob\n",
+    "cd $TOP/dépôt-bob\n",
     "git pull --no-edit github devel "
    ]
   },
@@ -2209,7 +2209,7 @@
    },
    "outputs": [],
    "source": [
-    "cd $TOP/repo-bob\n",
+    "cd $TOP/dépôt-bob\n",
     "git push github devel"
    ]
   },
@@ -2237,7 +2237,7 @@
    "outputs": [],
    "source": [
     "# et alice peut tirer\n",
-    "cd $TOP/repo-alice\n",
+    "cd $TOP/dépôt-alice\n",
     "git pull github devel"
    ]
   },
@@ -2271,7 +2271,7 @@
     }
    },
    "source": [
-    "* on copie un repo avec `clone`"
+    "* on copie un dépôt avec `clone`"
    ]
   },
   {

--- a/notebooks/4-01-managing-changes.ipynb
+++ b/notebooks/4-01-managing-changes.ipynb
@@ -50,7 +50,7 @@
    "source": [
     "## point de départ\n",
     "\n",
-    "nous repartons du `repo-alice` du scénario précédent"
+    "nous repartons du `dépôt-alice` du scénario précédent"
    ]
   },
   {
@@ -78,8 +78,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# si nécessaire, on se place dans le repo git\n",
-    "[ -d repo-alice ] && cd repo-alice\n",
+    "# si nécessaire, on se place dans le dépôt git\n",
+    "[ -d dépôt-alice ] && cd dépôt-alice\n",
     "\n",
     "pwd"
    ]
@@ -103,7 +103,7 @@
    },
    "outputs": [],
    "source": [
-    "# nous sommes dans 'repo-alice' qui a 5 commits\n",
+    "# nous sommes dans 'dépôt-alice' qui a 5 commits\n",
     "\n",
     "git l"
    ]
@@ -287,7 +287,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "travaille uniquement **à partir du repo**  (ignore les fichiers)"
+    "travaille uniquement **à partir du dépôt**  (ignore les fichiers)"
    ]
   },
   {
@@ -328,7 +328,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "travaille uniquement **à partir du repo**  (ignore les fichiers)"
+    "travaille uniquement **à partir du dépôt**  (ignore les fichiers)"
    ]
   },
   {

--- a/notebooks/4-03-rewrite-history.ipynb
+++ b/notebooks/4-03-rewrite-history.ipynb
@@ -48,7 +48,7 @@
     }
    },
    "source": [
-    "## `repo-rebase`"
+    "## `dépôt-rebase`"
    ]
   },
   {
@@ -61,16 +61,16 @@
     "\n",
     "# pour pouvoir recommencer le scénario depuis le début\n",
     "# je nettoie complètement ce qu'on a pu faire précédemment\n",
-    "if [ -d repo-rebase ]; then\n",
+    "if [ -d dépôt-rebase ]; then\n",
     "    echo \"on repart d'un directory vide\"\n",
-    "    rm -rf repo-rebase\n",
+    "    rm -rf dépôt-rebase\n",
     "fi\n",
     "\n",
     "# on le crée\n",
-    "mkdir repo-rebase\n",
+    "mkdir dépôt-rebase\n",
     "\n",
     "# on va dedans\n",
-    "cd repo-rebase"
+    "cd dépôt-rebase"
    ]
   },
   {
@@ -142,7 +142,7 @@
     }
    },
    "source": [
-    "## un repo"
+    "## un dépôt"
    ]
   },
   {
@@ -521,7 +521,7 @@
     "\n",
     "Alice peut decider de passer outre mais pour cela elle doit invoquer `git push --force`. \n",
     "\n",
-    "Ce serait une mauvaise idée dans ce cas car, sauf à contacter bob directement pour qu'il nettoie son repo, la prochaine fois que bob va tirer il va créer un commit B'', qui sera le troisième commit qui traite du même changement, et avec un fort risque de conflit en plus !"
+    "Ce serait une mauvaise idée dans ce cas car, sauf à contacter bob directement pour qu'il nettoie son dépôt, la prochaine fois que bob va tirer il va créer un commit B'', qui sera le troisième commit qui traite du même changement, et avec un fort risque de conflit en plus !"
    ]
   },
   {
@@ -546,7 +546,7 @@
     "   \n",
     "1. même scénario, mais vous créez une branche `bookmark`  \n",
     "   juste avant le `amend` pour vérifier  \n",
-    "   que le premier commit est toujours présent dans le repo\n",
+    "   que le premier commit est toujours présent dans le dépôt\n",
     "   \n",
     "1. créez un commit  \n",
     "   ajoutez des changements dans l'index  \n",
@@ -571,7 +571,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "1. créer un repo avec 5 commits init, bugfix1, feature1, bugfix2, feature2  \n",
+    "1. créer un dépôt avec 5 commits init, bugfix1, feature1, bugfix2, feature2  \n",
     "1. utiliser `rebase -i` pour récrire au dessus de init  \n",
     "   le même contenu en seulement 2 commit feature, bugfix\n",
     "1. créer une branche au niveau de init, lui appliquer le commit bugfix  \n",

--- a/notebooks/4-04-implementation.ipynb
+++ b/notebooks/4-04-implementation.ipynb
@@ -30,7 +30,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*très rapidement montrer à quoi ressemblent les objets du repo*\n",
+    "*très rapidement montrer à quoi ressemblent les objets du dépôt*\n",
     "\n",
     "* commit\n",
     "* tree\n",


### PR DESCRIPTION
This patch slightly changes the working to be more consistent.

The work "repo" is an anglicism used through the text, this patch
replaces the following occurences:

- "repo" → "dépôt"
- "repos" → "dépôts"